### PR TITLE
Improve interactions with the hover ring

### DIFF
--- a/neural_nets.js
+++ b/neural_nets.js
@@ -229,7 +229,8 @@ CellView.prototype.hits = function(p) {
 };
 
 CellView.prototype.hitsConnectors = function(p) {
-    return p.inCircle(this.pos, this.radius + this.connectorPadding * 1.5);
+    var OUTSIDE_PADDING = 6;
+    return p.inCircle(this.pos, this.radius + this.connectorPadding + OUTSIDE_PADDING);
 };
 
 CellView.prototype.isPositionOnOutputSide = function(mousePos) {

--- a/neural_nets.js
+++ b/neural_nets.js
@@ -1269,17 +1269,20 @@ function drawSim(ctx, canvas, sim) {
     drawFibers(ctx, sim.net);
     drawCells(ctx, sim.net, sim.fontsize);
 
+    var drawingFiberToInput = false;
+    var drawingFiberToOutput = false;
+
     if (sim.tool) {
         if (sim.tool instanceof FiberTool) {
             drawPartialFiber(ctx, sim.tool, sim.mousePos);
-            drawHoverRing(ctx, sim.net, sim.mousePos, !!sim.tool.from, !!sim.tool.to);
+            drawingFiberToInput = !!sim.tool.from;
+            drawingFiberToOutput = !!sim.tool.to;
         } else if (gSim.tool instanceof SelectTool) {
             drawSelectBox(ctx, sim.tool, sim.mousePos);
         }
-    } else {
-        drawHoverRing(ctx, sim.net, sim.mousePos, false, false);
     }
 
+    drawHoverRing(ctx, sim.net, sim.mousePos, drawingFiberToInput, drawingFiberToOutput);
     drawTextLabels(ctx, sim.net, sim.selection, sim.fontsize);
 }
 

--- a/neural_nets.js
+++ b/neural_nets.js
@@ -222,15 +222,20 @@ CellView.prototype = Object.create(Cell.prototype);
 CellView.prototype.constructor = CellView;
 
 CellView.prototype.radius = CellView.radius;
-CellView.prototype.connectorPadding = 12.0;
+CellView.prototype.connectorPadding = 11.0;
 
 CellView.prototype.hits = function(p) {
     return p.inCircle(this.pos, this.radius);
 };
 
 CellView.prototype.hitsConnectors = function(p) {
-    return p.inCircle(this.pos, this.radius + this.connectorPadding);
+    return p.inCircle(this.pos, this.radius + this.connectorPadding * 1.5);
 };
+
+CellView.prototype.isPositionOnOutputSide = function(mousePos) {
+    var dir = Vec.sub(mousePos, this.pos);
+    return Vec.dot(dir, Vec.fromAngle(this.angle)) > 0.0;
+}
 
 function LabelView(i) {
     Label.call(this, i);
@@ -908,7 +913,7 @@ function FiberTool(sim, e, cell) {
 
     var dir = Vec.sub(this.sim.mousePos, cell.pos);
  
-    if (Vec.dot(dir, Vec.fromAngle(cell.angle))  > 0.0) {
+    if (cell.isPositionOnOutputSide(this.sim.mousePos)) {
         this.from = cell;
     } else {
         this.to = cell;
@@ -1267,12 +1272,14 @@ function drawSim(ctx, canvas, sim) {
     if (sim.tool) {
         if (sim.tool instanceof FiberTool) {
             drawPartialFiber(ctx, sim.tool, sim.mousePos);
+            drawHoverRing(ctx, sim.net, sim.mousePos, !!sim.tool.from, !!sim.tool.to);
         } else if (gSim.tool instanceof SelectTool) {
             drawSelectBox(ctx, sim.tool, sim.mousePos);
         }
+    } else {
+        drawHoverRing(ctx, sim.net, sim.mousePos, false, false);
     }
 
-    drawHoverRing(ctx, sim.net, sim.mousePos);
     drawTextLabels(ctx, sim.net, sim.selection, sim.fontsize);
 }
 
@@ -1284,24 +1291,52 @@ function clearCanvas(ctx, canvas) {
     return ctx.fill();
 }
 
-function drawHoverRing(ctx, net, mousePos) {
+function drawHoverRing(ctx, net, mousePos, drawingFiberToInput, drawingFiberToOutput) {
+    var INACTIVE_COLOR = '#B0B0B0';
+    var HIGHLIGHT_COLOR = '#0000FF';
+    
     var i;
     var cell;
+    var highlightInput;
+    var highlightOutput;
     var radius;
+    var angleOffset;
+
     for (i = 0; i < net.cells.length; ++i) {
         cell = net.cells[i];
-        if (cell.hitsConnectors(mousePos) &&
-            !cell.hits(mousePos)) {
+
+        if (cell.hitsConnectors(mousePos)) {
+            // If the user is using the fiber tool to create a new fiber, we
+            // want to highlight the portion of the hover ring that the user can
+            // connect the fiber to. Otherwise, we want highlight the portion
+            // of the hover ring that the user is hovering over.
+            if (drawingFiberToInput || drawingFiberToOutput) {
+                highlightOutput = drawingFiberToOutput;
+                highlightInput = drawingFiberToInput;
+            } else if (cell.hits(mousePos)) {
+                highlightOutput = false;
+                highlightInput = false;
+            } else {
+                highlightOutput = cell.isPositionOnOutputSide(mousePos);
+                highlightInput = !highlightOutput;
+            }
 
             radius = cell.radius + cell.connectorPadding;
-            ctx.strokeStyle = '#0000FF';
             ctx.lineWidth = 1;
             ctx.setLineDash([4]);
 
-            ctx.beginPath();
-            ctx.arc(cell.pos.x, cell.pos.y, radius, 0.0, Math.PI * 2.0, false);
+            angleOffset = cell.angle !== ANGLE_EAST ? 0 : Math.PI * 1;
 
+            ctx.beginPath();
+            ctx.strokeStyle = highlightOutput ? HIGHLIGHT_COLOR : INACTIVE_COLOR;
+            ctx.arc(cell.pos.x, cell.pos.y, radius, Math.PI * 0.5 + angleOffset, Math.PI * 1.5 + angleOffset, false);
             ctx.stroke();
+
+            ctx.beginPath();
+            ctx.strokeStyle = highlightInput ? HIGHLIGHT_COLOR : INACTIVE_COLOR;
+            ctx.arc(cell.pos.x, cell.pos.y, radius, Math.PI * -0.5 + angleOffset, Math.PI * -1.5 + angleOffset, false);
+            ctx.stroke();
+
             ctx.lineWidth = 1;
             ctx.setLineDash([]);
         }


### PR DESCRIPTION
When the user mouses over the middle of a cell, we've been completely hiding the hover ring. I've found this to be pretty distracting though, especially since moving between the input to output sides of a cell causes the hover ring to flicker briefly.

This change makes it so the hover ring is shown even when the user's mouse is directly over a cell. To make it more obvious that there's special functionality available if the user clicks on the hover ring itself, we can use a faint stroke color when the mouse is over the cell and a more prominent highlight color when the mouse is over the hover ring.

In addition to using a more prominent color, we can also use the more prominent color on only half of the hover ring based on which side of the cell the user is hovering over. This makes it more obvious that the side of the hover ring that a user clicks on matters.